### PR TITLE
feature: Make use of MFA for some cache selectors

### DIFF
--- a/lib/nostrum/cache/guild/guild_server.ex
+++ b/lib/nostrum/cache/guild/guild_server.ex
@@ -55,6 +55,11 @@ defmodule Nostrum.Cache.Guild.GuildServer do
     call(guild_id, {:select, fun})
   end
 
+  @spec select_mfa(Guild.id(), {module, atom, [any]}) :: any
+  def select_mfa(guild_id, mfa) do
+    call(guild_id, {:select_mfa, mfa})
+  end
+
   @doc false
   def delete(guild_id) do
     call(guild_id, {:delete})
@@ -126,6 +131,10 @@ defmodule Nostrum.Cache.Guild.GuildServer do
 
   def handle_call({:select, fun}, _from, state) do
     {:reply, fun.(state), state, :hibernate}
+  end
+
+  def handle_call({:select_mfa, {m, f, a}}, _from, state) do
+    {:reply, apply(m, f, [state | a]), state, :hibernate}
   end
 
   def handle_call({:update, guild}, _from, state) do

--- a/lib/nostrum/cache/guild_cache.ex
+++ b/lib/nostrum/cache/guild_cache.ex
@@ -119,6 +119,11 @@ defmodule Nostrum.Cache.GuildCache do
     select_by(%{id: id}, selector)
   end
 
+  @spec select_mfa(Guild.id(), {module, atom, [any]}) :: {:ok, any} | {:error, reason}
+  def select_mfa(id, {m, f, a}) do
+    select_by(%{id: id}, fn guild -> apply(m, f, [guild | a]) end)
+  end
+
   @doc ~S"""
   Same as `select/2`, but raises `Nostrum.Error.CacheError` in case of failure.
   """


### PR DESCRIPTION
In a distributed setup with multiple nodes, the API that accepts anonymous functions only works if the caller (client) and the agent have the same version of the caller module.